### PR TITLE
Update the spec.template to allow for %pre and %postun to work

### DIFF
--- a/root/usr/share/multipkg/templates/spec.template
+++ b/root/usr/share/multipkg/templates/spec.template
@@ -16,6 +16,11 @@ Obsoletes: %obsoletelist%
 %description
 %summary%
 
+%%ifscript(pre.sh)
+%pre
+%%pre.sh%%
+%%endif
+
 %%ifscript(post.sh)
 %post
 %%post.sh%%
@@ -26,3 +31,7 @@ Obsoletes: %obsoletelist%
 %%preun.sh%%
 %%endif
 
+%%ifscript(postun.sh)
+%postun
+%%postun.sh%%
+%%endif


### PR DESCRIPTION
%pre and %postun are valid stages in an rpm installation and it'd be nice if multipkg supported the inclusion of scripts into the spec file for handling those situations.
