### PR TITLE
Add posttrans script to RPM spec template

### DIFF
--- a/root/usr/share/multipkg/templates/spec.template
+++ b/root/usr/share/multipkg/templates/spec.template
@@ -35,3 +35,8 @@ Obsoletes: %obsoletelist%
 %postun
 %%postun.sh%%
 %%endif
+
+%%ifscript(posttrans.sh)
+%posttrans
+%%posttrans.sh%%
+%%endif


### PR DESCRIPTION
Post transaction is a bit of a safety net for cases where the postun is
all screwed up.  Therefor it's useful to keep in the template.
