### PR TITLE
add support of installing build requires before building

### DIFF
--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -163,8 +163,8 @@ sub _init {
 }
 
 sub need_build_require {
-    warn "WARN: Don't know how to check if build requires installed."
-         ." You gonna check it yourself\n";
+    warn "WARN: Don't know how to install build requires."
+         ." Please install yourself.\n";
     0;
 }
 


### PR DESCRIPTION
A configuration using buildrequires may looks like,

``` yaml

default:
  buildrequires:
    - libpcre-devel
    - zlib-devel
```

now, multipkg will check for missing requires and install them before build a package.
