### PR TITLE
fix rpm build failure when filename contains spaces

### DIFF
--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -842,10 +842,10 @@ sub makepackage {
     }
 
     if ( -d _ ) {
-      print $f $rpmattr . "\%dir /$_\n" if ( -e "$path/.keep" );
+      print $f "\"" . $rpmattr . "\%dir /$_\"\n" if ( -e "$path/.keep" );
     }
     else {
-      print $f $rpmattr . "/$_\n";
+      print $f "\"" . $rpmattr . "/$_\"\n";
     }
   }
 


### PR DESCRIPTION
rpmbuild fails if a filename contains spaces. So, quote filename strings with double-quotes.
