### PR TITLE
Enable Prefix: to be specified in RPMs to create relocatable packages.

### DIFF
--- a/root/usr/share/multipkg/templates/spec.template
+++ b/root/usr/share/multipkg/templates/spec.template
@@ -12,6 +12,9 @@ autoreqprov: no
 Requires: %requirelist%
 Conflicts: %conflictlist%
 Obsoletes: %obsoletelist%
+%%ifset(prefix)
+Prefix: %prefix%
+%%endif
 
 %description
 %summary%

--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -243,6 +243,24 @@ sub template_string {
       next;
     }
 
+    # XXX: use of '%' prefix potentially conflicts with RPM specfile syntax
+    if (/^%%ifset\(([A-Za-z\.]+)\)$/) {
+      my $match = $1;
+
+      # increase nesting count for every nested %%if statement when we are inside an
+      # %%if which evaluated false.
+      if ($skipping) {
+        $skipping++;
+        next;
+      }
+
+      # start skipping lines once we hit a false %%if statement.
+      if ( !$self->info->data->{$match} ) {
+        $skipping++;
+      }
+      next;
+    }
+
     # reduce the nesting count for each %%endif until we leave the original %%if
     # that evaluated false.
     if (/^%%endif$/) {


### PR DESCRIPTION
@grierj @eam I'm using this to make a relocatable ruby RPM.
