### PR TITLE
fix shebang mung error on /usr/bin/env

### DIFF
--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -615,6 +615,8 @@ sub shebangmunge {
       my $firstline = <$g>;
       next unless ( $firstline =~ m#^\#\!(/.*/)(\w+)\s+?(.*)# );
       my ( $path, $interpreter, $options ) = ( $1, $2, $3 );
+      # skip shebang like '/usr/bin/env perl'.
+      next if $interpreter eq 'env';
 
       if ( $self->info->data->{$interpreter} ) {
         $self->infomsg("SHEBANG-MUNGING $interpreter: $dirname/$f");


### PR DESCRIPTION
currently, multipkg will broke shebang like "/usr/bin/env perl". this fix lets multipkg skip shebang mung when encounters an 'env' command.
