### PR TITLE
Better platform support for modern RHEL

### DIFF
--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -1338,6 +1338,17 @@ sub _init {
 
   $finaldata->{whoami} = _whoami();
 
+  if ( $self->{verbose} ) {
+    $self->infomsg( "Data:" );
+    foreach my $key ( keys %$finaldata ) {
+      $self->infomsg( "    $key: $finaldata->{$key}" );
+    }
+    $self->infomsg( "Scripts" );
+    foreach my $key ( keys %$scripts ) {
+      $self->infomsg( "    $key: $scripts->{$key}" );
+    }
+  }
+
   $self->data($finaldata);
   $self->scripts($scripts);
 
@@ -1433,7 +1444,9 @@ sub platforms {
     my $rel = <$f>;
     close $f;
 
-    if ( $rel =~ /Red Hat Enterprise Linux AS release (\S+)/ ) {
+    if ( $rel =~ /Red Hat Enterprise Linux .* release (\S+)/ ) {
+      my @parts = split /\./, $1;
+      push @platforms, "rhel-$parts[0]";
       push @platforms, "rhel-$1";
     }
 
@@ -1451,6 +1464,7 @@ sub platforms {
 
   unshift @platforms, 'default';
   $self->{platforms} = \@platforms;
+  $self->infomsg( "Platforms: " . join(",", @platforms) );
   return @platforms;
 }
 


### PR DESCRIPTION
- detect platform on modern RHEL variants more reliably
- allow packages to treat RHEL6 and RHEL7 as separate platforms
- add some debug prints useful for understanding platforms